### PR TITLE
add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # Other generated files
 htmlcov
-.coverage
+.coverage*
 
 # Sphinx
 doc/api

--- a/app.py
+++ b/app.py
@@ -311,7 +311,7 @@ def add_zcat_columns(targetcat, specprod):
 
 def parse_radec_string(radec):
     try:
-        ra,dec,radius = inventory.parse_radec_string(radec)
+        ra,dec,radius = inventory.parse_radec(radec)
     except ValueError as err:
         message = f'Could not parse "{radec}" as RA,DEC,RADIUS: {str(err)}'
         raise ValueError(message)
@@ -404,10 +404,13 @@ def plot_tiles_targets_fibers(specprod, tileid, fibers):
     specprod = standardize_specprod(specprod)
     try:
         format_type = get_table_format()
+        fibers = parse_fibers(fibers)
     except ValueError as err:
         return render_template("error.html", code=400, summary='Bad Request', message=str(err)), 400
 
-    fibers = parse_fibers(fibers)
+    if np.min(fibers) < 0 or np.max(fibers) > 4999:
+        msg = 'Fibers must be in the range 0-4999'
+        return render_template("error.html", code=400, summary='Bad Request', message=msg), 400
 
     #- Find LASTNIGHT for this tile
     try:

--- a/test_webapp.py
+++ b/test_webapp.py
@@ -1,0 +1,258 @@
+import os
+import unittest
+from io import BytesIO
+import warnings
+import base64
+from astropy.table import Table
+import numpy as np
+
+from app import app
+
+#- Utility to temporarily override environment variables while safely cleaning up
+#- Written by LBL CBorg Coder AI
+from contextlib import ContextDecorator
+class EnvironmentVariable(ContextDecorator):
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self.original_value = None
+
+    def __enter__(self):
+        self.original_value = os.getenv(self.key)
+        if self.value is None:
+            if self.original_value is not None:
+                del os.environ[self.key]
+        else:
+            os.environ[self.key] = self.value
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.original_value is not None:
+            os.environ[self.key] = self.original_value
+        elif self.key in os.environ:
+            del os.environ[self.key]
+
+
+class FlaskAppTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+
+        warnings.filterwarnings("ignore", message=r".*Cannot merge meta key .*", category=Warning)
+
+    def tearDown(self):
+        warnings.resetwarnings()
+
+    #---------------------------------------------------------------------
+    #- non-data pages
+
+    def test_info_pages(self):
+        for page in ('', 'search', 'examples', 'license', 'about'):
+            response = self.app.get(f'/{page}')
+            self.assertEqual(response.status_code, 200)
+
+    def test_nonexistent_page(self):
+        response = self.app.get('/nonexistent')
+        self.assertEqual(response.status_code, 404)
+
+    def test_auth(self):
+        """Confirm that all proprietary endpoints require authorization"""
+        #- these should give 401 = unauthorized
+        for release in ('dr2', 'daily', 'blatfoo'):
+            for targspec in ('targets', 'spectra'):
+                for tilepix in ('', 'tiles', 'healpix'):
+                    for search in ('radec/210,5,30',  # RA,dec cone search
+                                   '150/0-5',         # TILEID/FIBERs
+                                   '1234,5678'        # TARGETIDs
+                                   ):
+                        #- TILEID/FIBERs search doesn't apply for healpix
+                        if tilepix=='healpix' and search=='150/0-5':
+                            continue
+
+                        url = f'/{release}/{targspec}/{tilepix}/{search}'.replace('//', '/')
+                        response = self.app.get(url)
+                        errmsg = f"{url} didn't return 401=Unauthorized"
+                        self.assertEqual(response.status_code, 401, errmsg)
+
+        #- successful authorization with fake credentials
+        with EnvironmentVariable('DESI_COLLAB_USERNAME', 'blat'):
+            with EnvironmentVariable('DESI_COLLAB_PASSWORD', 'foo'):
+                #- success
+                auth_bytes = "blat:foo".encode('utf-8')
+                base64_bytes = base64.b64encode(auth_bytes)
+                base64_string = base64_bytes.decode('utf-8')
+                headers = {'Authorization': f'Basic {base64_string}'}
+                response = self.app.get('/dr2/targets/tiles/7614/1500-1503', headers=headers)
+                self.assertEqual(response.status_code, 200)
+
+                #- wrong password = fail
+                auth_bytes = "blat:bizbat".encode('utf-8')
+                base64_bytes = base64.b64encode(auth_bytes)
+                base64_string = base64_bytes.decode('utf-8')
+                headers = {'Authorization': f'Basic {base64_string}'}
+                response = self.app.get('/dr2/targets/tiles/7614/1500-1503', headers=headers)
+                self.assertEqual(response.status_code, 401)
+
+
+
+    #---------------------------------------------------------------------
+    #- Targets
+
+    def test_targets_radec(self):
+        #- basic
+        response = self.app.get('/dr1/targets/radec/210,5,30')
+        self.assertEqual(response.status_code, 200)
+
+        #- healpix is default
+        response_healpix = self.app.get('/dr1/targets/healpix/radec/210,5,30')
+        self.assertEqual(response_healpix.status_code, 200)
+        data = response_healpix.data.replace(b'/healpix/', b'/')
+        self.assertEqual(data, response.data)
+
+        #- tiles
+        response_tiles = self.app.get('/dr1/targets/tiles/radec/210,5,30')
+        self.assertEqual(response_tiles.status_code, 200)
+        self.assertNotEqual(response_healpix.data, response_tiles.data)
+
+        #- radius optional if within 10" of a target
+        response = self.app.get('/dr1/targets/radec/210,4.9946')
+        self.assertEqual(response.status_code, 200)
+
+        #- other data releases
+        for release in ('edr', 'fuji', 'iron'):
+            response = self.app.get(f'/{release}/targets/radec/210,4.9946')
+            self.assertEqual(response.status_code, 200)
+
+    def test_targets_radec_formats(self):
+        for format in ('html', 'fits', 'json'):
+            response = self.app.get(f'/dr1/targets/radec/210,5,30?format={format}')
+            self.assertEqual(response.status_code, 200)
+
+        #- csv and ascii should be directly parseable by astropy.table.Table
+        for format in ('csv', 'ascii'):
+            response = self.app.get(f'/dr1/targets/radec/210,5,30?format={format}')
+            t = Table.read(BytesIO(response.data), format=format)
+            self.assertEqual(len(t), 4)
+
+    #- TODO: some of these are 500 internal server errors intead of 400/404
+    @unittest.expectedFailure
+    def test_targets_radec_failures(self):
+        #- 400 Bad Request if outside DESI footprint
+        response = self.app.get('/dr1/targets/radec/210,-80,10')
+        self.assertEqual(response.status_code, 400)
+
+        #- ra,dec out of range
+        response = self.app.get('/dr1/targets/radec/210,100,10')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/targets/radec/210,-100,10')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/targets/radec/410,10,10')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/targets/radec/-10,10,10')
+        self.assertEqual(response.status_code, 400)
+
+        #- malformed ra,dec,radius
+        response = self.app.get('/dr1/targets/radec/210')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/targets/radec/1,2,3,4')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/targets/radec/200deg,10deg,5arcsec')
+        self.assertEqual(response.status_code, 400)
+
+    def test_targets_tilefibers(self):
+        #- basic
+        response = self.app.get('/dr1/targets/150/0-5,10,20:22')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/targets/tiles/150/0-5,10,20:22')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/targets/tiles/150/0-5,10,20:22?format=fits')
+        self.assertEqual(response.status_code, 200)
+
+        #- various ways of specifying fiber ranges
+        t = Table.read(BytesIO(self.app.get('/dr1/targets/tiles/150/0:5?format=csv').data), format='csv')
+        self.assertEqual(len(t), 5)
+        self.assertTrue(np.all(t['FIBER'] == np.arange(5)))
+
+        t = Table.read(BytesIO(self.app.get('/dr1/targets/tiles/150/0-5?format=csv').data), format='csv')
+        self.assertEqual(len(t), 6)
+        self.assertTrue(np.all(t['FIBER'] == np.arange(6)))
+
+        t = Table.read(BytesIO(self.app.get('/dr1/targets/tiles/150/10,5,0?format=csv').data), format='csv')
+        self.assertEqual(len(t), 3)
+        self.assertTrue(np.all(t['FIBER'] == np.array([10,5,0])))
+
+    def test_targets_tiles_failures(self):
+        #- tile not found
+        #- 404 Not Found; not 400 Bad Request, since someday that tile might exists
+        response = self.app.get('/dr1/targets/tiles/999999/0-5')
+        self.assertEqual(response.status_code, 404)
+
+        #- fibers out of range (400 Bad Request because these fibers will never be valid)
+        response = self.app.get('/dr1/targets/tiles/150/10000-10002')
+        self.assertEqual(response.status_code, 400)
+
+    def test_targets_targetids(self):
+        #- basic
+        response = self.app.get('/dr1/targets/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/targets/healpix/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/targets/tiles/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+
+        t = Table.read(BytesIO(self.app.get('/dr1/targets/39627908959964170,39627908959964322?format=csv').data), format='csv')
+        self.assertEqual(len(t), 3)  #- one target observed in both sv3 and main
+
+        #- filter by SURVEY
+        t = Table.read(BytesIO(self.app.get('/dr1/targets/39627908959964170,39627908959964322?SURVEY=sv3&format=csv').data), format='csv')
+        self.assertEqual(len(t), 2)
+
+    #---------------------------------------------------------------------
+    #- Spectra
+    #- slower, so less complete coverage of all matrix options
+
+    def test_spectra_radec(self):
+        #- basic
+        response = self.app.get('/dr1/spectra/radec/210,5,30')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/spectra/healpix/radec/210,5,30')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/dr1/spectra/tiles/radec/210,5,30')
+        self.assertEqual(response.status_code, 200)
+
+        #- fits
+        response = self.app.get('/dr1/spectra/radec/210,5,30?format=fits')
+        self.assertEqual(response.status_code, 200)
+
+        #- plotting with noise model
+        response = self.app.get('/dr1/spectra/radec/210,5,30?plotnoise=1')
+        self.assertEqual(response.status_code, 200)
+
+    def test_spectra_tilefibers(self):
+        #- basic
+        response = self.app.get('/dr1/spectra/150/0,2,3')
+        self.assertEqual(response.status_code, 200)
+
+    def test_spectra_targetids(self):
+        #- basic (defaults to healpix)
+        response = self.app.get('/dr1/spectra/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+        #- healpix
+        response = self.app.get('/dr1/spectra/healpix/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+        #- tiles
+        response = self.app.get('/dr1/spectra/tiles/39627908959964170,39627908959964322')
+        self.assertEqual(response.status_code, 200)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds tests. `inspector.auth` has 100% coverage, while `app.py` has 82% coverage. Most of the uncovered code is various failure modes, e.g. the response if the TARGETID strings aren't TARGETIDs. This PR also includes a set of failure tests currently flagged as expected to fail because the webapp is returning non-ideal error codes., e.g., 500 Internal Server Error instead of 400 Bad Request. That, along with the uncovered code, will be easier to fix after some code refactoring to reduce replicated code.