### PR TITLE
separate flask app from non-flask code

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,9 +161,14 @@ def render_table_ascii(table, ascii_format):
     response = make_response(result)
 
     user_agent = request.headers.get('User-Agent', '').lower()
-    print(user_agent)
+    ### print(user_agent)
     if 'wget' in user_agent or 'curl' in user_agent:
-        response.headers['Content-Disposition'] = f'attachment; filename=desi-inventory.txt'
+        if ascii_format == 'csv':
+            filename = 'desi-targets.csv'
+        else:
+            filename = 'desi-targets.txt'
+
+        response.headers['Content-Disposition'] = f'attachment; filename={filename}'
         response.headers['Content-Type'] = 'text/plain'
     else:
         response.headers['Content-Type'] = 'text/plain'
@@ -178,7 +183,7 @@ def render_table_fits(table):
 
     response = make_response(result)
 
-    response.headers['Content-Disposition'] = f'attachment; filename=desi-inventory.fits'
+    response.headers['Content-Disposition'] = f'attachment; filename=desi-targets.fits'
     response.headers['Content-Type'] = 'application/fits'
 
     return response
@@ -499,6 +504,7 @@ def spectra_tiles_fibers(specprod, tileid, fibers):
     elif format_type == 'fits':
         return render_spectra_fits(spectra)
     else:
+        #- Upstream code should have validated format_type, but catch here just in case
         msg = f'Unrecognized format {format_type}'
         return render_template("error.html", code=400, summary='Bad Request', message=msg), 400
 

--- a/app.py
+++ b/app.py
@@ -40,41 +40,6 @@ _MAX_RADIUS_ERROR_MESSAGE = f'Please limit your search to radius < {_MAX_RADIUS}
 _MAX_SPECTRA=1000
 _MAX_SPECTRA_ERROR_MESSAGE = '{} spectra is more than we can realistically display; please limit your search to fewer than {} spectra'
 
-def _standardize_specprod(specprod):
-    """
-    Return standardized specprod with aliases for dr1 -> iron, etc.
-    """
-    specprod = specprod.lower()
-    if specprod == 'edr':
-        return 'fuji'
-    elif specprod == 'dr1':
-        return 'iron'
-    elif specprod == 'dr2':
-        return 'loa'
-    else:
-        return specprod
-
-def _parse_fibers(fibers_string):
-    """
-    Parse fiber strings like "0-5,10:12,25" -> [0,1,2,3,4,5,10,11,25]
-    Note: A-B is inclusive of B, while A:B is python-like exclusive of B
-    """
-    fibers = list()
-    for token in fibers_string.split(','):
-        if token.isdigit():
-            fibers.append(int(token))
-        elif '-' in token:
-            first, last = token.split('-')
-            fibers.extend( np.arange(int(first), int(last)+1) )
-        elif ':' in token:
-            first, last = token.split(':')
-            fibers.extend( np.arange(int(first), int(last)) )
-        else:
-            raise ValueError(f'Failed to parse {token} as part of {fibers_string}')
-
-    return fibers
-
-
 @app.route("/testargs")
 def test_filter():
     print(type(request.args))
@@ -267,97 +232,9 @@ def get_filters():
     """
     return request.args.to_dict(flat=False)
 
-def _filter_table(table, args=None):
-    """
-    Filter a Table based upon URL args dict
-
-    TODO: expand explanation, args comes from request.args.to_dict(flat=False)
-    """
-    if args is None:
-        args = request.args.to_dict(flat=False)
-    elif isinstance(args, werkzeug.datastructures.structures.MultiDict):
-        args = args.to_dict(flat=False)
-
-    keep = np.ones(len(table), dtype=bool)
-    for column, filter_list in args.items():
-        if column not in table.colnames:
-            continue
-        for filt in filter_list:
-            if ':' in filt:
-                operator, value = filt.split(':')
-            else:
-                operator = 'eq'
-                value = filt
-
-            value = np.array(value, dtype=table[column].dtype)
-            print(f'Filter {column} {operator} {value}')
-
-            if operator == 'eq':
-                keep &= (table[column] == value)
-            elif operator == 'lt':
-                keep &= (table[column] < value)
-            elif operator == 'le':
-                keep &= (table[column] <= value)
-            elif operator == 'gt':
-                keep &= (table[column] > value)
-            elif operator == 'ge':
-                keep &= (table[column] >= value)
-            elif operator == 'ne':
-                keep &= (table[column] != value)
-            else:
-                #- TODO: handle error message with error message to user
-                print(f'ERROR: unrecognized operator {operator}')
-
-    return table[keep]
-
-def _add_zcat_columns(targetcat, specprod):
-    """
-    Return copy of targetcat with zcat columns added
-
-    Adds TARGET_RA, TARGET_DEC, SPECTYPE, Z, ZWARN
-    """
-    t = targetcat.copy(copy_data=False)
-    zcat = read_redrock_targetcat(t, fmcols=['TARGET_RA', 'TARGET_DEC'], specprod=specprod)
-    for col in ['TARGET_RA', 'TARGET_DEC', 'SPECTYPE', 'Z', 'ZWARN']:
-        t[col] = zcat[col]
-
-    return t
-
-def _parse_radec_string(radec):
-    try:
-        ra,dec,radius = inventory.parse_radec(radec)
-    except ValueError as err:
-        message = f'Could not parse "{radec}" as RA,DEC,RADIUS: {str(err)}'
-        raise ValueError(message)
-
-    if radius > MAX_RADIUS:
-        raise ValueError(MAX_RADIUS_ERROR_MESSAGE)
-
-    return ra,dec,radius
 
 #-------------------------------------------------------------------------
 #- Inventory of targets
-
-def _load_targets(specprod, specgroup, radec=None, targetids=None):
-    """
-    required: specprod, specgroup; plus radec OR targetids (but not both)
-    """
-    specprod = standardize_specprod(specprod)
-
-    if radec is not None:
-        radec = validate_radec(radec)
-    elif targetids is not None:
-        targetids = list(map(int, targetids.split(',')))
-    else:
-        raise ValueError('must specify radec or targetids')
-
-    if specgroup == 'healpix':
-        t = inventory.target_healpix(radec=radec, targetids=targetids, specprod=specprod)
-    elif specgroup == 'tiles':
-        t = inventory.target_tiles(radec=radec, targetids=targetids, specprod=specprod)
-
-    t = filter_table(add_zcat_columns(t, specprod))
-    return t
 
 def render_targets(specprod, specgroup, radec=None, targetids=None):
     """
@@ -510,25 +387,6 @@ def render_spectra_fits(spectra):
     response.headers['Content-Type'] = 'application/fits'
 
     return response
-
-def _load_spectra(specprod, specgroup, radec=None, targetids=None, maxspectra=MAX_SPECTRA):
-    """
-    Required: specprod, specgroup; and radec OR targetids (but not both)
-
-    TODO: separate loading spectra from flask-specific rendering
-    """
-    specprod = standardize_specprod(specprod)
-    targetcat = load_targets(specprod, specgroup=specgroup, radec=radec, targetids=targetids)
-
-    num_spectra = len(targetcat)
-    if num_spectra == 0:
-        return None
-    elif num_spectra > MAX_SPECTRA:
-        raise ValueError(MAX_SPECTRA_ERROR_MESSAGE.format(num_spectra, maxspectra))
-
-    print(f'Reading {num_spectra} spectra')
-    spectra = read_spectra_parallel(targetcat, specprod=specprod, rdspec_kwargs=dict(return_redshifts=True))
-    return spectra
 
 def render_spectra(specprod, specgroup, radec=None, targetids=None):
     try:

--- a/app.py
+++ b/app.py
@@ -26,19 +26,14 @@ from flask import Flask, request, jsonify, render_template, make_response, Respo
 import werkzeug.datastructures.structures
 
 from inspector.auth import conditional_auth
-from inspector.io import (standardize_specprod, parse_fibers, validate_radec, load_targets, load_spectra,
+from inspector.io import (standardize_specprod, parse_fibers, validate_radec,
+                          load_targets, load_spectra,
                           filter_table, add_zcat_columns,
                           MAX_SPECTRA, MAX_SPECTRA_ERROR_MESSAGE)
 
 
 app = Flask(__name__)
 app.url_map.strict_slashes = False
-
-_MAX_RADIUS=1800  # 0.5 deg
-_MAX_RADIUS_ERROR_MESSAGE = f'Please limit your search to radius < {_MAX_RADIUS} arcsec'
-
-_MAX_SPECTRA=1000
-_MAX_SPECTRA_ERROR_MESSAGE = '{} spectra is more than we can realistically display; please limit your search to fewer than {} spectra'
 
 ### @app.route("/testargs")
 ### def test_filter():

--- a/inspector/io.py
+++ b/inspector/io.py
@@ -1,0 +1,161 @@
+"""
+inspector.io
+============
+"""
+
+import numpy as np
+from desispec import inventory
+from desispec.io import read_spectra_parallel
+from desispec.io.redrock import read_redrock_targetcat
+
+MAX_RADIUS=1800  # 0.5 deg
+MAX_RADIUS_ERROR_MESSAGE = f'Please limit your search to radius < {MAX_RADIUS} arcsec'
+
+MAX_SPECTRA=1000
+MAX_SPECTRA_ERROR_MESSAGE = '{} spectra is more than we can realistically display; please limit your search to fewer than {} spectra'
+
+def standardize_specprod(specprod):
+    """
+    Return standardized specprod with aliases for dr1 -> iron, etc.
+    """
+    specprod = specprod.lower()
+    if specprod == 'edr':
+        return 'fuji'
+    elif specprod == 'dr1':
+        return 'iron'
+    elif specprod == 'dr2':
+        return 'loa'
+    else:
+        return specprod
+
+
+def parse_fibers(fibers_string):
+    """
+    Parse fiber strings like "0-5,10:12,25" -> [0,1,2,3,4,5,10,11,25]
+    Note: A-B is inclusive of B, while A:B is python-like exclusive of B
+    """
+    fibers = list()
+    for token in fibers_string.split(','):
+        if token.isdigit():
+            fibers.append(int(token))
+        elif '-' in token:
+            first, last = token.split('-')
+            fibers.extend( np.arange(int(first), int(last)+1) )
+        elif ':' in token:
+            first, last = token.split(':')
+            fibers.extend( np.arange(int(first), int(last)) )
+        else:
+            raise ValueError(f'Failed to parse {token} as part of {fibers_string}')
+
+    return fibers
+
+
+def validate_radec(radec):
+    ra,dec,radius = inventory.parse_radec(radec)
+    if radius > MAX_RADIUS:
+        raise ValueError(MAX_RADIUS_ERROR_MESSAGE)
+    if ra<0 or ra>360:
+        raise ValueError(f'RA={ra} should be between 0 and 360 degrees')
+    if dec<-90 or dec>90:
+        raise ValueError(f'dec={dec} should be between -90 and 90 degrees')
+
+    return ra,dec,radius
+
+def add_zcat_columns(targetcat, specprod):
+    """
+    Return copy of targetcat with zcat columns added
+    
+    Adds TARGET_RA, TARGET_DEC, SPECTYPE, Z, ZWARN
+    """
+    t = targetcat.copy(copy_data=False)
+    zcat = read_redrock_targetcat(t, fmcols=['TARGET_RA', 'TARGET_DEC'], specprod=specprod)
+    for col in ['TARGET_RA', 'TARGET_DEC', 'SPECTYPE', 'Z', 'ZWARN']:
+        t[col] = zcat[col]
+    
+    return t
+
+def filter_table(table, filters):
+    """
+    Filter a Table based upon URL args dict
+
+    TODO: expand explanation, args comes from request.args.to_dict(flat=False)
+    """
+
+    #- support blank or None filters
+    if filters is None or len(filters) == 0:
+        return table
+
+    keep = np.ones(len(table), dtype=bool)
+    for column, filter_list in filters.items():
+        if column not in table.colnames:
+            continue
+        for filt in filter_list:
+            if ':' in filt:
+                operator, value = filt.split(':')
+            else:
+                operator = 'eq'
+                value = filt
+
+            value = np.array(value, dtype=table[column].dtype)
+            print(f'Filter {column} {operator} {value}')
+
+            if operator == 'eq':
+                keep &= (table[column] == value)
+            elif operator == 'lt':
+                keep &= (table[column] < value)
+            elif operator == 'le':
+                keep &= (table[column] <= value)
+            elif operator == 'gt':
+                keep &= (table[column] > value)
+            elif operator == 'ge':
+                keep &= (table[column] >= value)
+            elif operator == 'ne':
+                keep &= (table[column] != value)
+            else:
+                #- TODO: handle error message with error message to user
+                raise ValueError(f'Unrecognized operator {operator}')
+
+    return table[keep]
+
+def load_targets(specprod, specgroup, radec=None, targetids=None, filters=None):
+    """
+    required: specprod, specgroup; plus radec OR targetids (but not both)
+    """
+    specprod = standardize_specprod(specprod)
+
+    if radec is not None:
+        radec = validate_radec(radec)
+    elif targetids is not None:
+        targetids = list(map(int, targetids.split(',')))
+    else:
+        raise ValueError('must specify radec or targetids')
+
+    if specgroup == 'healpix':
+        t = inventory.target_healpix(radec=radec, targetids=targetids, specprod=specprod)
+    elif specgroup == 'tiles':
+        t = inventory.target_tiles(radec=radec, targetids=targetids, specprod=specprod)
+
+    t = add_zcat_columns(t, specprod)
+    t = filter_table(t, filters)
+
+    return t
+
+def load_spectra(specprod, specgroup, radec=None, targetids=None, filters=None, maxspectra=MAX_SPECTRA):
+    """
+    Required: specprod, specgroup; and radec OR targetids (but not both)
+
+    TODO: separate loading spectra from flask-specific rendering
+    """
+    specprod = standardize_specprod(specprod)
+    targetcat = load_targets(specprod, specgroup=specgroup, radec=radec, targetids=targetids, filters=filters)
+
+    num_spectra = len(targetcat)
+    if num_spectra == 0:
+        return None
+    elif num_spectra > MAX_SPECTRA:
+        raise ValueError(MAX_SPECTRA_ERROR_MESSAGE.format(num_spectra, maxspectra))
+
+    print(f'Reading {num_spectra} spectra')
+    spectra = read_spectra_parallel(targetcat, specprod=specprod, rdspec_kwargs=dict(return_redshifts=True))
+    return spectra
+

--- a/test_io.py
+++ b/test_io.py
@@ -1,0 +1,114 @@
+"""
+Test some desispec.io functionality not covered by the webapp cases
+"""
+
+import unittest
+
+class TestIO(unittest.TestCase):
+
+    def test_parse_fibers(self):
+        from inspector.io import parse_fibers
+
+        self.assertEqual(parse_fibers('10,20,30'), [10,20,30])
+        self.assertEqual(parse_fibers('0:4'), [0,1,2,3])
+        self.assertEqual(parse_fibers('0-4'), [0,1,2,3,4])
+        self.assertEqual(parse_fibers('0:2,10,20-22'), [0,1,10,20,21,22])
+        self.assertEqual(parse_fibers('100-103,0:2,10,20-22'), [100,101,102,103,0,1,10,20,21,22])
+
+        with self.assertRaises(ValueError):
+            fibers = parse_fibers('1,a,2')      # error: not integers
+
+        with self.assertRaises(ValueError):
+            fibers = parse_fibers('1,-3,2')     # error: negative fiber number
+
+        with self.assertRaises(ValueError):
+            fibers = parse_fibers('three-four') # error: not integers
+
+        with self.assertRaises(ValueError):
+            fibers = parse_fibers('10-5')       # error: first>last
+
+        with self.assertRaises(ValueError):
+            fibers = parse_fibers('10:5')       # error: first>last
+
+    def test_validate_radec(self):
+        from inspector.io import validate_radec
+
+        self.assertEqual(validate_radec('10,20,30'), (10.0,20.0,30.0))
+        self.assertEqual(validate_radec('10.5,-20,30'), (10.5,-20.0,30.0))
+        self.assertEqual(validate_radec('10,-20.3'), (10.0,-20.3,10.0))
+
+        with self.assertRaises(ValueError):
+            ra,dec,radius = validate_radec('10,20,10000')    # radius too big
+
+        with self.assertRaises(ValueError):
+            ra,dec,radius = validate_radec('-10,20,30')      # RA<0
+
+        with self.assertRaises(ValueError):
+            ra,dec,radius = validate_radec('360.1,20,30')    # RA>360
+
+        with self.assertRaises(ValueError):
+            ra,dec,radius = validate_radec('10,-100,30')    # dec<-90
+
+        with self.assertRaises(ValueError):
+            ra,dec,radius = validate_radec('10,100,30')    # dec>90
+
+    def test_filter_table(self):
+        from astropy.table import Table
+        from inspector.io import filter_table
+        table = Table()
+        table['A'] = list(range(10))
+
+        #- scalar or list, number or string
+        for value in [3, '3', [3,], ['3',], (3,)]:
+            t = filter_table(table, dict(A=value))
+            self.assertEqual(list(t['A']), [3,], f'Failed comparison test with {value=}')
+
+        t = filter_table(table, dict(A='eq:5'))
+        self.assertEqual(list(t['A']), [5,])
+
+        t = filter_table(table, dict(A='gt:7'))
+        self.assertEqual(list(t['A']), [8,9,])
+
+        t = filter_table(table, dict(A='ge:7'))
+        self.assertEqual(list(t['A']), [7,8,9,])
+
+        t = filter_table(table, dict(A='lt:3'))
+        self.assertEqual(list(t['A']), [0,1,2,])
+
+        t = filter_table(table, dict(A='le:3'))
+        self.assertEqual(list(t['A']), [0,1,2,3,])
+
+        t = filter_table(table, dict(A='ne:4'))
+        self.assertEqual(list(t['A']), [0,1,2,3,5,6,7,8,9])
+
+        t = filter_table(table, dict(A=['ge:3', 'le:7']))
+        self.assertEqual(list(t['A']), [3,4,5,6,7])
+
+        with self.assertRaises(ValueError):
+            t = filter_table(table, dict(A='xx:25'))
+
+        with self.assertRaises(ValueError):
+            t = filter_table(table, dict(A='eq:blat'))
+
+    def test_load_targets(self):
+        """Test failure mode of load_targets"""
+        from inspector.io import load_targets
+        with self.assertRaises(ValueError):
+            targets = load_targets('dr1', 'healpix')  # needs radec or targetids
+
+    def test_load_spectra(self):
+        """Test failure mode of load_spectra"""
+        from inspector.io import load_spectra
+        spectra = load_spectra('dr1', 'healpix', targetids=[1,2,3])
+        self.assertEqual(spectra, None)
+
+        spectra = load_spectra('dr1', 'healpix', targetids=[])
+        self.assertEqual(spectra, None)
+
+        targetids = [39627908959964170, 39627908959964322]
+        with self.assertRaises(ValueError):
+            sp = load_spectra('dr1', 'healpix', targetids=targetids, maxspectra=1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_webapp.py
+++ b/test_webapp.py
@@ -11,7 +11,7 @@ from app import app
 #- Utility to temporarily override environment variables while safely cleaning up
 #- Written by LBL CBorg Coder AI
 from contextlib import ContextDecorator
-class EnvironmentVariable(ContextDecorator):
+class TempEnvironmentVariable(ContextDecorator):
     def __init__(self, key, value):
         self.key = key
         self.value = value
@@ -46,7 +46,7 @@ class FlaskAppTestCase(unittest.TestCase):
     #- non-data pages
 
     def test_info_pages(self):
-        for page in ('', 'search', 'examples', 'license', 'about'):
+        for page in ('', 'search', 'examples', 'license', 'about', 'robots.txt', 'dr1/testauth'):
             response = self.app.get(f'/{page}')
             self.assertEqual(response.status_code, 200)
 
@@ -74,8 +74,8 @@ class FlaskAppTestCase(unittest.TestCase):
                         self.assertEqual(response.status_code, 401, errmsg)
 
         #- successful authorization with fake credentials
-        with EnvironmentVariable('DESI_COLLAB_USERNAME', 'blat'):
-            with EnvironmentVariable('DESI_COLLAB_PASSWORD', 'foo'):
+        with TempEnvironmentVariable('DESI_COLLAB_USERNAME', 'blat'):
+            with TempEnvironmentVariable('DESI_COLLAB_PASSWORD', 'foo'):
                 #- success
                 auth_bytes = "blat:foo".encode('utf-8')
                 base64_bytes = base64.b64encode(auth_bytes)
@@ -134,11 +134,11 @@ class FlaskAppTestCase(unittest.TestCase):
             self.assertEqual(len(t), 4)
 
     def test_targets_radec_failures(self):
-        #- 400 Bad Request if outside DESI footprint
+        #- 404 Not Found if no targets found, e.g. outside of footprint
         response = self.app.get('/dr1/targets/radec/210,-80,10')
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
-        #- ra,dec out of range
+        #- 400 Bad Request if ra,dec out of range
         response = self.app.get('/dr1/targets/radec/210,100,10')
         self.assertEqual(response.status_code, 400)
 
@@ -159,6 +159,10 @@ class FlaskAppTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
         response = self.app.get('/dr1/targets/radec/200deg,10deg,5arcsec')
+        self.assertEqual(response.status_code, 400)
+
+        #- invalid format
+        response = self.app.get('/dr1/targets/radec/210,5,30?format=invalid')
         self.assertEqual(response.status_code, 400)
 
     def test_targets_tilefibers(self):
@@ -195,6 +199,10 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/targets/tiles/150/10000-10002')
         self.assertEqual(response.status_code, 400)
 
+        #- bad format
+        response = self.app.get('/dr1/targets/150/0-5?format=invalid')
+        self.assertEqual(response.status_code, 400)
+
     def test_targets_targetids(self):
         #- basic
         response = self.app.get('/dr1/targets/39627908959964170,39627908959964322')
@@ -212,6 +220,7 @@ class FlaskAppTestCase(unittest.TestCase):
         #- filter by SURVEY
         t = Table.read(BytesIO(self.app.get('/dr1/targets/39627908959964170,39627908959964322?SURVEY=sv3&format=csv').data), format='csv')
         self.assertEqual(len(t), 2)
+
 
     #---------------------------------------------------------------------
     #- Spectra
@@ -251,6 +260,25 @@ class FlaskAppTestCase(unittest.TestCase):
         #- tiles
         response = self.app.get('/dr1/spectra/tiles/39627908959964170,39627908959964322')
         self.assertEqual(response.status_code, 200)
+
+    def test_spectra_failures(self):
+        #- bad format
+        response = self.app.get('/dr1/spectra/radec/210,5,30?format=invalid')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/spectra/tiles/1000/0-10?format=blatfoo')
+        self.assertEqual(response.status_code, 400)
+
+        #- no spectra found
+        response = self.app.get('/dr1/spectra/radec/10,-80,10')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/spectra/1,2,3')
+        self.assertEqual(response.status_code, 400)
+
+        #- too many spectra for a single request
+        response = self.app.get('/dr1/spectra/tiles/1000/0:5000')
+        self.assertEqual(response.status_code, 400)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_webapp.py
+++ b/test_webapp.py
@@ -133,8 +133,6 @@ class FlaskAppTestCase(unittest.TestCase):
             t = Table.read(BytesIO(response.data), format=format)
             self.assertEqual(len(t), 4)
 
-    #- TODO: some of these are 500 internal server errors intead of 400/404
-    @unittest.expectedFailure
     def test_targets_radec_failures(self):
         #- 400 Bad Request if outside DESI footprint
         response = self.app.get('/dr1/targets/radec/210,-80,10')

--- a/test_webapp.py
+++ b/test_webapp.py
@@ -250,6 +250,9 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/spectra/150/0,2,3')
         self.assertEqual(response.status_code, 200)
 
+        response = self.app.get('/dr1/spectra/150/0,2,3?format=fits')
+        self.assertEqual(response.status_code, 200)
+
     def test_spectra_targetids(self):
         #- basic (defaults to healpix)
         response = self.app.get('/dr1/spectra/39627908959964170,39627908959964322')
@@ -262,6 +265,8 @@ class FlaskAppTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_spectra_failures(self):
+        #--- 400 Bad Request cases ---
+
         #- bad format
         response = self.app.get('/dr1/spectra/radec/210,5,30?format=invalid')
         self.assertEqual(response.status_code, 400)
@@ -269,16 +274,22 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/spectra/tiles/1000/0-10?format=blatfoo')
         self.assertEqual(response.status_code, 400)
 
-        #- no spectra found
-        response = self.app.get('/dr1/spectra/radec/10,-80,10')
-        self.assertEqual(response.status_code, 400)
-
-        response = self.app.get('/dr1/spectra/1,2,3')
-        self.assertEqual(response.status_code, 400)
-
         #- too many spectra for a single request
         response = self.app.get('/dr1/spectra/tiles/1000/0:5000')
         self.assertEqual(response.status_code, 400)
+
+        #--- 404 Not Found cases ---
+
+        #- no spectra found
+        response = self.app.get('/dr1/spectra/radec/10,-80,10')
+        self.assertEqual(response.status_code, 404)
+
+        response = self.app.get('/dr1/spectra/1,2,3')
+        self.assertEqual(response.status_code, 404)
+
+        #- tile not in this production
+        response = self.app.get('/dr1/spectra/99999/0,2,3?format=fits')
+        self.assertEqual(response.status_code, 404)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR isolated non-flask code into separate `inspector.io` and `inspector.auth` code, leaving the flask-specific code in `app.py`.  It also improves the test coverage and does various cleanup on error checking.  Core functionality and features remains unchanged, other than returning more informative error pages when something goes wrong.  This lays the groundwork for implementing new features with better structure and testing.