### PR TITLE
add_zcat_columns add TARGETID if missing

### DIFF
--- a/inspector/io.py
+++ b/inspector/io.py
@@ -75,6 +75,9 @@ def add_zcat_columns(targetcat, specprod):
     zcat = read_redrock_targetcat(t, fmcols=['TARGET_RA', 'TARGET_DEC'], specprod=specprod)
     for col in ['TARGET_RA', 'TARGET_DEC', 'SPECTYPE', 'Z', 'ZWARN']:
         t[col] = zcat[col]
+
+    if 'TARGETID' not in t.colnames:
+        t['TARGETID'] = zcat['TARGETID']
     
     return t
 


### PR DESCRIPTION
This PR fixes #7 where filtering on TARGETID wasn't working for the spectra view.  It turns out that this was specific to the spectra view of TILEID+FIBERs.  Since that didn't need TARGETID to look up the spectra on disk, that column wasn't included in the table and thus the filter wasn't being applied.

The solution was to add TARGETID regardless as part of add_zcat_columns.

I'll separately address the issue of filters silently not being applied (e.g. due to a column typo); see #5 .