### PR TITLE
fix/catch bad filter cases

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,7 +310,7 @@ def targets_tiles_fibers(specprod, tileid, fibers):
         lastnight = get_lastnight(tileid, specprod=specprod)
     except ValueError as err:
         msg = f'Tile {tileid} not found in {specprod} production'
-        return render_template("error.html", code=404, summary='Not Found', message=str(err)), 404
+        return render_template("error.html", code=404, summary='Not Found', message=str(msg)), 404
 
     #- read fibermaps to find the TARGETIDs for these fibers
     fiber2targetid = dict()
@@ -329,8 +329,11 @@ def targets_tiles_fibers(specprod, tileid, fibers):
     targetcat['LASTNIGHT'] = lastnight
     targetcat['FIBER'] = fibers
 
-    filters = get_filters()
-    targetcat = filter_table(add_zcat_columns(targetcat, specprod), filters=filters)
+    try:
+        filters = get_filters()
+        targetcat = filter_table(add_zcat_columns(targetcat, specprod), filters=filters)
+    except ValueError as err:
+        return render_template("error.html", code=400, summary='Bad Request', message=str(err)), 400
 
     return render_table(targetcat, format_type)
 
@@ -410,7 +413,8 @@ def render_spectra_fits(spectra):
 def render_spectra(specprod, specgroup, radec=None, targetids=None):
     try:
         format_type = get_spectra_format()
-        spectra = load_spectra(specprod, specgroup=specgroup, radec=radec, targetids=targetids)
+        filters = get_filters()
+        spectra = load_spectra(specprod, specgroup=specgroup, radec=radec, targetids=targetids, filters=filters)
     except ValueError as err:
         return render_template("error.html", code=400, summary='Bad Request', message=str(err)), 400
 
@@ -487,8 +491,11 @@ def spectra_tiles_fibers(specprod, tileid, fibers):
     targetcat['LASTNIGHT'] = lastnight
     targetcat['TILEID'] = tileid
 
-    filters = get_filters()
-    targetcat = filter_table(add_zcat_columns(targetcat, specprod), filters)
+    try:
+        filters = get_filters()
+        targetcat = filter_table(add_zcat_columns(targetcat, specprod), filters)
+    except ValueError as err:
+        return render_template("error.html", code=400, summary='Bad Request', message=str(err)), 400
 
     print(f'Reading {len(targetcat)} spectra')
     print(targetcat)

--- a/inspector/io.py
+++ b/inspector/io.py
@@ -95,8 +95,14 @@ def filter_table(table, filters):
 
     keep = np.ones(len(table), dtype=bool)
     for column, filter_list in filters.items():
-        if column not in table.colnames:
+        #- Interpret UPPERCASE as columns for filter; otherwise other options
+        if not column.isupper():
             continue
+
+        #- If UPPERCASE but not in the table columns, that is an error
+        if column not in table.colnames:
+            raise ValueError(f'Filter column "{column}" not in {table.colnames}')
+
         filter_list = np.atleast_1d(filter_list)
         for filt in filter_list:
             if isinstance(filt, str) and ':' in filt:

--- a/test_webapp.py
+++ b/test_webapp.py
@@ -165,6 +165,10 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/targets/radec/210,5,30?format=invalid')
         self.assertEqual(response.status_code, 400)
 
+        #- Bad filter (should be Z, not REDSHIFT)
+        response = self.app.get('/dr1/targets/radec/210,5,30?REDSHIFT=gt:1.0')
+        self.assertEqual(response.status_code, 400)
+
     def test_targets_tilefibers(self):
         #- basic
         response = self.app.get('/dr1/targets/150/0-5,10,20:22')
@@ -203,6 +207,10 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/targets/150/0-5?format=invalid')
         self.assertEqual(response.status_code, 400)
 
+        #- bad filter
+        response = self.app.get('/dr1/targets/150/0-5?BLAT=foo')
+        self.assertEqual(response.status_code, 400)
+
     def test_targets_targetids(self):
         #- basic
         response = self.app.get('/dr1/targets/39627908959964170,39627908959964322')
@@ -221,6 +229,14 @@ class FlaskAppTestCase(unittest.TestCase):
         t = Table.read(BytesIO(self.app.get('/dr1/targets/39627908959964170,39627908959964322?SURVEY=sv3&format=csv').data), format='csv')
         self.assertEqual(len(t), 2)
 
+    def test_targets_targetids_failures(self):
+        #- bad format
+        response = self.app.get('/dr1/targets/healpix/39627908959964170,39627908959964322?format=spreadsheet')
+        self.assertEqual(response.status_code, 400)
+
+        #- bad filter
+        response = self.app.get('/dr1/targets/healpix/39627908959964170,39627908959964322?BLAT=foo')
+        self.assertEqual(response.status_code, 400)
 
     #---------------------------------------------------------------------
     #- Spectra
@@ -271,7 +287,20 @@ class FlaskAppTestCase(unittest.TestCase):
         response = self.app.get('/dr1/spectra/radec/210,5,30?format=invalid')
         self.assertEqual(response.status_code, 400)
 
+        response = self.app.get('/dr1/spectra/39627908959964170,39627908959964322?format=bizbat')
+        self.assertEqual(response.status_code, 400)
+
         response = self.app.get('/dr1/spectra/tiles/1000/0-10?format=blatfoo')
+        self.assertEqual(response.status_code, 400)
+
+        #- bad filter
+        response = self.app.get('/dr1/spectra/radec/210,5,30?BLAT=foo')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/spectra/39627908959964170,39627908959964322?Z=qq:1.0')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get('/dr1/spectra/tiles/1000/0-10?Z=gt:hello')
         self.assertEqual(response.status_code, 400)
 
         #- too many spectra for a single request


### PR DESCRIPTION
This PR:
* fixes spectra cases where filters weren't applied even if requested
* returns an informative 400 error page if filters are mis-specified, e.g. missing column or wrong syntax
* add more tests

fixes #5 